### PR TITLE
Update FDTakeController.m

### DIFF
--- a/FDTakeExample/FDTakeController.m
+++ b/FDTakeExample/FDTakeController.m
@@ -309,8 +309,13 @@ static NSString * const kStringsTableName = @"FDTake";
         }
         else {
             // Otherwise use iPhone style action sheet presentation.
-            [self.actionSheet showInView:[self presentingViewController].view];
-        }
+  	    UIWindow* window = [[[UIApplication sharedApplication] delegate] window];
+            if ([window.subviews containsObject:[self presentingViewController].view]) {
+                [self.actionSheet showInView:[self presentingViewController].view];
+            } else {
+                [self.actionSheet showInView:window];
+            	}
+            }
     } else {
         NSString *str = [self textForButtonWithTitle:kNoSourcesKey];
         [[[UIAlertView alloc] initWithTitle:nil


### PR DESCRIPTION
This fixes this crash for me:

**\* Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: 'Sheet can not be presented because the view is not in a window: <SWRevealView: 0x15533840; frame = (0 0; 320 568); autoresize = W+H; layer = <CALayer: 0x155247c0>>'
**\* First throw call stack:
(0x307dee83 0x3ab3b6c7 0x331493d3 0x331b0a51 0x163fd5 0x16125f 0xd9c35 0xfd667 0x32e58893 0x330e9ea3 0x32f97355 0x32f92451 0x32f67d79 0x32f66569 0x307a9f1f 0x307a93e7 0x307a7bd7 0x30712471 0x30712253 0x3544c2eb 0x32fc7845 0x14a129 0x3b034ab7)
libc++abi.dylib: terminating with uncaught exception of type NSException
(lldb) 

http://stackoverflow.com/questions/18932544/nsinvalidargumentexception-reason-sheet-can-not-be-presented-because-the-vi
