### PR TITLE
Adds localization strings files back to podspec resources

### DIFF
--- a/FDTake.podspec
+++ b/FDTake.podspec
@@ -12,5 +12,6 @@ Pod::Spec.new do |s|
   s.platform     = :ios, "5.0"
   s.source       = { :git => "https://github.com/fulldecent/FDTake.git", :tag => "v0.2.3" }
   s.source_files  = "FDTakeExample/FDTakeController.{h,m}"
+  s.resources = "FDTakeExample/*.lproj"
   s.requires_arc = true
 end


### PR DESCRIPTION
The resources were accidentally removed in a previous commit, so using FDTake via cocoa pods resulted in no string translations including english. `chooseFromLibrary` and `takePhoto` were displayed.
