### PR TITLE
Solved issue #60 that produced a crash running the example

### DIFF
--- a/FDTakeExample/FDTakeController.m
+++ b/FDTakeExample/FDTakeController.m
@@ -382,7 +382,7 @@ static NSString * const kStringsTableName = @"FDTake";
         NSString* frameworkBundlePath = [mainBundlePath stringByAppendingPathComponent:@"FDTakeResources.bundle"];
         frameworkBundle = [NSBundle bundleWithPath:frameworkBundlePath];
     });
-    return frameworkBundle;
+    return frameworkBundle ?: [NSBundle mainBundle];
 }
 
 static inline NSString * FDLOCALIZATION(NSString *key, NSString *comment) {


### PR DESCRIPTION
I have solved the issue #60 that crashed the example app.
In fact when an user simply downloaded the project from github, the localized strings where in the mainBundle and not in the FDTakeResources.bundle available only with cocoapod.