### PR TITLE
Solved issue #56 adding support on UIBarButtonItem on iPad

### DIFF
--- a/FDTakeExample/FDTakeController.h
+++ b/FDTakeExample/FDTakeController.h
@@ -37,14 +37,35 @@
 @interface FDTakeController : NSObject <UIImagePickerControllerDelegate>
 
 /**
+ *  Presents the user with an option to take a photo or choose a photo from the library
+ *
+ *  @param sender The sender (e.g. UIButton, UIBarButtonItem) passed in the IBAction that call this method
+ */
+- (void)takePhotoOrChooseFromLibrary:(id)sender;
+
+/**
  * Presents the user with an option to take a photo or choose a photo from the library
  */
 - (void)takePhotoOrChooseFromLibrary;
 
 /**
+ *  Presents the user with an option to take a video or choose a video from the library
+ *
+ *  @param sender The sender (e.g. UIButton, UIBarButtonItem) passed in the IBAction that call this method
+ */
+- (void)takeVideoOrChooseFromLibrary:(id)sender;
+
+/**
  * Presents the user with an option to take a video or choose a video from the library
  */
 - (void)takeVideoOrChooseFromLibrary;
+
+/**
+ *  Presents the user with an option to take a photo/video or choose a photo/video from the library
+ *
+ *  @param sender The sender (e.g. UIButton, UIBarButtonItem) passed in the IBAction that call this method
+ */
+- (void)takePhotoOrVideoOrChooseFromLibrary:(id)sender;
 
 /**
  * Presents the user with an option to take a photo/video or choose a photo/video from the library

--- a/FDTakeExample/FDTakeController.m
+++ b/FDTakeExample/FDTakeController.m
@@ -33,7 +33,7 @@ static NSString * const kStringsTableName = @"FDTake";
 - (UIViewController*)presentingViewController;
 
 // encapsulation of actionsheet creation
-- (void)_setUpActionSheet;
+- (void)_setUpActionSheet:(id)sender;
 - (NSString*)textForButtonWithTitle:(NSString*)title;
 @end
 
@@ -82,7 +82,7 @@ static NSString * const kStringsTableName = @"FDTake";
     return _popover;
 }
 
-- (void)takePhotoOrChooseFromLibrary
+- (void)takePhotoOrChooseFromLibrary:(id)sender
 {
     self.sources = nil;
     self.buttonTitles = nil;
@@ -98,11 +98,16 @@ static NSString * const kStringsTableName = @"FDTake";
         [self.sources addObject:[NSNumber numberWithInteger:UIImagePickerControllerSourceTypeSavedPhotosAlbum]];
         [self.buttonTitles addObject:[self textForButtonWithTitle:kChooseFromPhotoRollKey]];
     }
-    [self _setUpActionSheet];
+    [self _setUpActionSheet:sender];
     [self.actionSheet setTag:kPhotosActionSheetTag];
 }
 
-- (void)takeVideoOrChooseFromLibrary
+- (void)takePhotoOrChooseFromLibrary
+{
+    [self takePhotoOrChooseFromLibrary:nil];
+}
+
+- (void)takeVideoOrChooseFromLibrary:(id)sender
 {
     self.sources = nil;
     self.buttonTitles = nil;
@@ -118,11 +123,16 @@ static NSString * const kStringsTableName = @"FDTake";
         [self.sources addObject:[NSNumber numberWithInteger:UIImagePickerControllerSourceTypeSavedPhotosAlbum]];
         [self.buttonTitles addObject:[self textForButtonWithTitle:kChooseFromPhotoRollKey]];
     }
-    [self _setUpActionSheet];
+    [self _setUpActionSheet:sender];
     [self.actionSheet setTag:kVideosActionSheetTag];
 }
 
-- (void)takePhotoOrVideoOrChooseFromLibrary
+- (void)takeVideoOrChooseFromLibrary
+{
+    [self takeVideoOrChooseFromLibrary:nil];
+}
+
+- (void)takePhotoOrVideoOrChooseFromLibrary:(id)sender
 {
     self.sources = nil;
     self.buttonTitles = nil;
@@ -139,8 +149,13 @@ static NSString * const kStringsTableName = @"FDTake";
         [self.sources addObject:[NSNumber numberWithInteger:UIImagePickerControllerSourceTypeSavedPhotosAlbum]];
         [self.buttonTitles addObject:[self textForButtonWithTitle:kChooseFromPhotoRollKey]];
     }
-    [self _setUpActionSheet];
+    [self _setUpActionSheet:sender];
     [self.actionSheet setTag:kVideosOrPhotosActionSheetTag];
+}
+
+- (void)takePhotoOrVideoOrChooseFromLibrary
+{
+    [self takePhotoOrVideoOrChooseFromLibrary:nil];
 }
 
 #pragma mark - UIActionSheetDelegate
@@ -296,7 +311,7 @@ static NSString * const kStringsTableName = @"FDTake";
     return [self topViewController:presentedViewController];
 }
 
-- (void)_setUpActionSheet
+- (void)_setUpActionSheet:(id)sender
 {
     if ([self.sources count]) {
         self.actionSheet = [[UIActionSheet alloc] initWithTitle:nil
@@ -311,7 +326,11 @@ static NSString * const kStringsTableName = @"FDTake";
         
         // If on iPad use the present rect and pop over style.
         if (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad) {
-            [self.actionSheet showFromRect:self.popOverPresentRect inView:[self presentingViewController].view animated:YES];
+            if ([sender isKindOfClass:[UIBarButtonItem class]]) {
+                [self.actionSheet showFromBarButtonItem:sender animated:YES];
+            } else {
+                [self.actionSheet showFromRect:self.popOverPresentRect inView:[self presentingViewController].view animated:YES];
+            }
         }
         else if(self.tabBar) {
             [self.actionSheet showFromTabBar:self.tabBar];


### PR DESCRIPTION
To support UIBarButtonItem on iPad, I needed to pass the sender object in the FDTakeController class so I have added this three methods in order to pass it:
- (void)takePhotoOrChooseFromLibrary:(id)sender;
- (void)takeVideoOrChooseFromLibrary:(id)sender;
- (void)takePhotoOrVideoOrChooseFromLibrary:(id)sender;

FDTake still works the same as before with the corresponding methods without the sender.