### PR TITLE
Don't display "DID SELECT" log

### DIFF
--- a/Pod/Classes/FDTakeController.swift
+++ b/Pod/Classes/FDTakeController.swift
@@ -255,8 +255,6 @@ public class FDTakeController: NSObject /* , UIImagePickerControllerDelegate, UI
                     // On iPad use pop-overs.
                     self.popover.presentPopoverFromRect(popOverPresentRect, inView: topVC.view!, permittedArrowDirections: .Any, animated: true)
                 }
-                
-                NSLog("DID SELECT!")
             }
             alertController!.addAction(action)
         }


### PR DESCRIPTION
I don't think it is necessary with a default log message you can't control, better to have people add their own logging.