### PR TITLE
Fix a crash of the example on iPad

### DIFF
--- a/Example/FDTake/ViewController.swift
+++ b/Example/FDTake/ViewController.swift
@@ -79,6 +79,7 @@ class ViewController: UIViewController {
 
     @IBAction func presentFromWindow(sender: UIButton) {
         resetFDTakeController()
+        fdTakeController.presentingView = self.view
         fdTakeController.present()
     }
 }


### PR DESCRIPTION
Set the presenting view when present from window is tapped. Fixes #84

The view appears in the top right which isn't completely satisfying but didn't want to overcomplicate the example as I think its clear you can set the presenting view to whatever works best for your application.